### PR TITLE
Which as GRangesList

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -36,6 +36,8 @@ export(SetdiffVariantsFilter, DepthFETFilter, MaxControlFreqFilter)
 
 export(callWildtype, minCallableCoverage)
 
+export(epGRanges)
+
 ## some utilities
 export(matchVariants, "%variant_in%", extractCoverageForPositions)
 export(pileupVariants)

--- a/R/epGRanges.R
+++ b/R/epGRanges.R
@@ -1,0 +1,46 @@
+## Equipartition GRanges:
+## Splits a GRanges object into a specified number of parts with equal (total) width.
+## Each part is a GRanges and all parts are returned as GRangesList object. 
+
+## Alexandre Kuhn (alexandre.m.kuhn@gmail.com)
+
+epGRanges<-function(gr,partitionNb) {
+        if (partitionNb<1) stop("The number of partition should be at least 1.")
+        else if (partitionNb==1) return(GRangesList(gr))
+        else
+        {
+        grLength<-length(gr)
+        cs<-cumsum(width(gr))
+
+        partitionWidth<-floor(cs[grLength]/partitionNb) #last partition is longer
+        #determine partitions' upper bounds (ub)
+        upperbound<-seq(partitionWidth,cs[grLength],partitionWidth)
+        upperbound[partitionNb]<-cs[grLength]
+
+        #for each ub, identify the gr element to which it locates
+        ubIndex<-sapply(upperbound,function(x){which(cs>=x)[1]})
+
+        #for each ub, determine its coord. relative to the gr element it locates to 
+        ubCoord<-rep(NA,partitionNb)
+        if (ubIndex[1]==1) ubCoord[1]<-start(gr[1])+partitionWidth-1
+        else ubCoord[1]<-start(gr[ubIndex[1]])+partitionWidth-cs[ubIndex[1]-1]-1
+        for (i in 2:partitionNb) {
+                if (ubIndex[i]==ubIndex[i-1]) ubCoord[i]<-ubCoord[i-1]+partitionWidth
+                else ubCoord[i]<-start(gr[ubIndex[i]])+i*partitionWidth-cs[ubIndex[i]-1]-1
+        }
+        ubCoord[partitionNb]<-end(gr[grLength]) #correct coord. of last upper bound
+
+        #use ub index and relative coordinates to generate GRangesList object
+        grl<-GRangesList()
+        if (ubIndex[1]==1) grl[[1]]<-restrict(gr[1],end=ubCoord[1])
+        else grl[[1]]<-c(gr[1:(ubIndex[1]-1)],restrict(gr[ubIndex[1]],end=ubCoord[1]))
+        for (i in 2:partitionNb) {
+                if (ubIndex[i]==ubIndex[i-1]) grl[[i]]<-restrict(gr[ubIndex[i]],start=ubCoord[i-1]+1,end=ubCoord[i])
+                else if (ubIndex[i]-ubIndex[i-1]==1) grl[[i]]<-c(restrict(gr[ubIndex[i-1]],start=ubCoord[i-1]+1),restrict(gr[ubIndex[i]],end=ubCoord[i]))
+                else if (ubIndex[i]-ubIndex[i-1]>1) grl[[i]]<-c(restrict(gr[ubIndex[i-1]],start=ubCoord[i-1]+1),gr[(ubIndex[i-1]+1):(ubIndex[i]-1)],restrict(gr[ubIndex[i]],end=ubCoord[i]))
+                else stop("Decreasing ubIndex")
+        }
+        return(grl)
+        }
+}
+

--- a/R/sampleSpecific.R
+++ b/R/sampleSpecific.R
@@ -46,7 +46,9 @@ setMethod("callSampleSpecificVariants", c("BamFile", "BamFile"),
             case.called <- callVariants(case.raw, calling.filters, post.filters)
 
             control.raw <- tallyVariants(control, tally.param)
-            sbp <- ScanBamParam(which = tally.param@bamTallyParam@which)
+            which <- tally.param@bamTallyParam@which
+            if (is(which, "GRangesList")) which<-unlist(which)
+            sbp <- ScanBamParam(which = which)
             control.cov <- coverage(control, drop.D.ranges = TRUE, param = sbp)
 
             callSampleSpecificVariants(case.called, control.raw,

--- a/R/tallyVariants.R
+++ b/R/tallyVariants.R
@@ -49,11 +49,14 @@ setMethod("tallyVariants", "BamFile",
             if (length(which) == 0L) {
               which <- tileGenome(seqlengths(param@bamTallyParam@genome),
                                   bpworkers(BPPARAM))
-            } else if (length(which) == 1L) {
-              which <- tile(which,
-                            n=min(width(which), bpworkers(BPPARAM)))[[1L]]
             }
-            which <- as(which, "List")
+            if (is(which,"GenomicRanges")) {
+		if (length(which) == 1L) {
+                    which <- tile(which,
+                            n=min(width(which), bpworkers(BPPARAM)))[[1L]]
+            	}
+                which <- as(which, "List")
+            }
             ans <- bplapply(which, tally_region_job, x = x, param = param,
                             BPPARAM = BPPARAM)
             do.call(c, unname(ans))

--- a/man/epGRanges.Rd
+++ b/man/epGRanges.Rd
@@ -1,13 +1,14 @@
 \name{epGRanges}
+\alias{epGRanges}
 \title{
   Equipartition a GRanges object. 
 }
 \description{
 Splits a GRanges object into a specified number of partitions with
-equal (total) width. This is useful for instance to ensure
-balanced loading of workers in parallel evaluation. Each partition
-is a GRanges and the set of all partitions is returned as
-GRangesList object. 
+equal (total) width. This is useful to ensure balanced
+worker load in parallel evaluation of tallies for instance.
+Each returned partition is a GRanges and the set of all partitions
+is returned as a GRangesList object. 
 }
 \usage{
 epGRanges(gr,partitionNb)

--- a/man/epGRanges.Rd
+++ b/man/epGRanges.Rd
@@ -1,0 +1,32 @@
+\name{epGRanges}
+\title{
+  Equipartition a GRanges object. 
+}
+\description{
+Splits a GRanges object into a specified number of partitions with
+equal (total) width. This is useful for instance to ensure
+balanced loading of workers in parallel evaluation. Each partition
+is a GRanges and the set of all partitions is returned as
+GRangesList object. 
+\usage{
+epGRanges(gr,partitionNb)
+}
+\arguments{
+  \item{gr}{
+    A \code{GRanges} object to be partitioned.
+  }
+  \item{partitionNb}{
+    The desired number of partitions.
+  }
+}
+\value{
+    A \code{GRangesList} object where all elements (\code{GRanges})
+    have the same (total) width.
+}
+\author{
+    Alexandre Kuhn
+}
+\examples{
+   gr<-GRanges(c("chr1","chr2"),IRanges(c(1,1),c(100,1e5)))
+   epGRanges(gr,2)   
+}

--- a/man/epGRanges.Rd
+++ b/man/epGRanges.Rd
@@ -8,6 +8,7 @@ equal (total) width. This is useful for instance to ensure
 balanced loading of workers in parallel evaluation. Each partition
 is a GRanges and the set of all partitions is returned as
 GRangesList object. 
+}
 \usage{
 epGRanges(gr,partitionNb)
 }

--- a/man/tallyVariants.Rd
+++ b/man/tallyVariants.Rd
@@ -27,6 +27,7 @@
 \S4method{tallyVariants}{BamFileList}(x, ...)
 \S4method{tallyVariants}{character}(x, ...)
 TallyVariantsParam(genome,
+                   which,
                    read_pos_breaks = NULL,
                    high_base_quality = 0L,
                    minimum_mapq = 13L,
@@ -67,9 +68,9 @@ TallyVariantsParam(genome,
     of length 1 it is tiled to create chunks for parallel evaluation.
     If it is longer than 1, each range becomes a chunk for parallel
     evaluation. If \code{which} is a ‘GRangesList’, each element
-    becomes a chunk. The latter can be useful to ensure equal loading
-    of workers in the case of regions covering multiple sequences (see
-    \code{\link{epGRanges}}). 
+    becomes a chunk. The latter can be useful to ensure balanced worker
+    load, e.g. in the case of regions covering multiple sequences
+    (see \code{\link{epGRanges}}). 
   }
   \item{read_pos_breaks}{The breaks used for tabulating the read positions (read
     positions) at each position. If this information is included (not

--- a/man/tallyVariants.Rd
+++ b/man/tallyVariants.Rd
@@ -60,6 +60,17 @@ TallyVariantsParam(genome,
   \item{genome}{The genome, either a \code{\link[gmapR]{GmapGenome}} or
     something coercible to one.
   }
+  \item{which}{A ‘RangesList’ or something coercible to one that
+    limits the tally to that range or set of ranges. By default,
+    the entire genome is processed. For parallel evaluation
+    (see \code{BPPARAM}): if \code{which} is a ‘GenomicRanges’
+    of length 1 it is tiled to create chunks for parallel evaluation.
+    If it is longer than 1, each range becomes a chunk for parallel
+    evaluation. If \code{which} is a ‘GRangesList’, each element
+    becomes a chunk. The latter can be useful to ensure equal loading
+    of workers in the case of regions covering multiple sequences (see
+    \code{\link{epGRanges}}). 
+  }
   \item{read_pos_breaks}{The breaks used for tabulating the read positions (read
     positions) at each position. If this information is included (not
     \code{NULL}), \code{\link{qaVariants}} will use it during filtering.

--- a/man/tallyVariants.Rd
+++ b/man/tallyVariants.Rd
@@ -22,13 +22,15 @@
   something coercible to one that limits the tally to that range or
   set of ranges. By default, the entire genome is processed.
 
-  For parallel evaluation (see \code{BPPARAM}): if \code{which}
-  is a ‘GenomicRanges’ of length 1 it is tiled to create chunks for
-  parallel evaluation. If it is longer than 1, each range becomes a
-  chunk for parallel evaluation. If \code{which} is a ‘GRangesList’,
-  each element becomes a chunk. The latter can be useful to ensure
-  balanced worker load, e.g. in the case of regions covering multiple
-  sequences(see \code{\link{epGRanges}}).
+  For parallel evaluation (see \code{BPPARAM}): Specifically,
+  \code{which} can be a ‘GenomicRanges’ or a ‘GRangesList’. If
+  \code{which} is a ‘GenomicRanges’ and has length 1 it is tiled
+  to create chunks for parallel evaluation. If it is longer
+  than 1, each range becomes a chunk for parallel evaluation.
+  If \code{which} is a ‘GRangesList’, each element (i.e. each
+  ‘GenomicRanges’) becomes a chunk. The latter can be useful to
+  ensure balanced worker load, e.g. in the case of regions covering
+  multiple sequences(see \code{\link{epGRanges}}).
 }
 \note{
   The \code{VariantTallyParam} constructor is \strong{DEPRECATED}.

--- a/man/tallyVariants.Rd
+++ b/man/tallyVariants.Rd
@@ -15,8 +15,20 @@
   for which an alternate base has been detected.  The typical usage is
   to pass a BAM file, the genome, the (fixed) \code{readlen} and (if the
   variant calling should consider quality) an appropriate
-  \code{high_base_quality} cutoff. Passing a \code{which} argument
-  allows computing on only a subregion of the genome.
+  \code{high_base_quality} cutoff.
+
+  Passing a \code{which} argument allows computing on only a
+  subregion of the genome. \code{which} is a ‘RangesList’ or
+  something coercible to one that limits the tally to that range or
+  set of ranges. By default, the entire genome is processed.
+
+  For parallel evaluation (see \code{BPPARAM}): if \code{which}
+  is a ‘GenomicRanges’ of length 1 it is tiled to create chunks for
+  parallel evaluation. If it is longer than 1, each range becomes a
+  chunk for parallel evaluation. If \code{which} is a ‘GRangesList’,
+  each element becomes a chunk. The latter can be useful to ensure
+  balanced worker load, e.g. in the case of regions covering multiple
+  sequences(see \code{\link{epGRanges}}).
 }
 \note{
   The \code{VariantTallyParam} constructor is \strong{DEPRECATED}.
@@ -27,7 +39,6 @@
 \S4method{tallyVariants}{BamFileList}(x, ...)
 \S4method{tallyVariants}{character}(x, ...)
 TallyVariantsParam(genome,
-                   which,
                    read_pos_breaks = NULL,
                    high_base_quality = 0L,
                    minimum_mapq = 13L,
@@ -60,17 +71,6 @@ TallyVariantsParam(genome,
   }
   \item{genome}{The genome, either a \code{\link[gmapR]{GmapGenome}} or
     something coercible to one.
-  }
-  \item{which}{A ‘RangesList’ or something coercible to one that
-    limits the tally to that range or set of ranges. By default,
-    the entire genome is processed. For parallel evaluation
-    (see \code{BPPARAM}): if \code{which} is a ‘GenomicRanges’
-    of length 1 it is tiled to create chunks for parallel evaluation.
-    If it is longer than 1, each range becomes a chunk for parallel
-    evaluation. If \code{which} is a ‘GRangesList’, each element
-    becomes a chunk. The latter can be useful to ensure balanced worker
-    load, e.g. in the case of regions covering multiple sequences
-    (see \code{\link{epGRanges}}). 
   }
   \item{read_pos_breaks}{The breaks used for tabulating the read positions (read
     positions) at each position. If this information is included (not


### PR DESCRIPTION
tallyVariants() and sampleSpecificVariants() accommodate param@bamTallyParam@which as 'GenomicRanges' or 'GRangesList'.

Passing a 'GRangesList' can help ensure balanced worker load. To this end, the helper function epGRanges() repartitions a Granges() into elements of equal width (returned as a 'GRangesList' that can be passed to tallyVariantsParam()). 