### PR TITLE
Equisplit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: VariantTools
 Type: Package
 Title: Tools for Exploratory Analysis of Variant Calls
-Version: 1.19.1
+Version: 1.19.2
 Author: Michael Lawrence, Jeremiah Degenhardt, Robert Gentleman
 Maintainer: Michael Lawrence <michafla@gene.com>
 Description: Explore, diagnose, and compare variant calls using filters.

--- a/R/sampleSpecific.R
+++ b/R/sampleSpecific.R
@@ -46,7 +46,10 @@ setMethod("callSampleSpecificVariants", c("BamFile", "BamFile"),
             case.called <- callVariants(case.raw, calling.filters, post.filters)
 
             control.raw <- tallyVariants(control, tally.param)
-            sbp <- ScanBamParam(which = tally.param@bamTallyParam@which)
+            
+            which <- tally.param@bamTallyParam@which
+            if (is(which, "GRangesList")) which<-unlist(which)
+            sbp <- ScanBamParam(which = which)
             control.cov <- coverage(control, drop.D.ranges = TRUE, param = sbp)
 
             callSampleSpecificVariants(case.called, control.raw,

--- a/R/tallyVariants.R
+++ b/R/tallyVariants.R
@@ -49,11 +49,14 @@ setMethod("tallyVariants", "BamFile",
             if (length(which) == 0L) {
               which <- tileGenome(seqlengths(param@bamTallyParam@genome),
                                   bpworkers(BPPARAM))
-            } else if (length(which) == 1L) {
-              which <- tile(which,
-                            n=min(width(which), bpworkers(BPPARAM)))[[1L]]
             }
-            which <- as(which, "List")
+            if (is(which,"GenomicRanges")) {
+ 		if (length(which) == 1L) {
+                     which <- tile(which,
+                             n=min(width(which), bpworkers(BPPARAM)))[[1L]]
+             	}
+                which <- as(which, "List")
+             }
             ans <- bplapply(which, tally_region_job, x = x, param = param,
                             BPPARAM = BPPARAM)
             do.call(c, unname(ans))

--- a/man/tallyVariants.Rd
+++ b/man/tallyVariants.Rd
@@ -15,8 +15,22 @@
   for which an alternate base has been detected.  The typical usage is
   to pass a BAM file, the genome, the (fixed) \code{readlen} and (if the
   variant calling should consider quality) an appropriate
-  \code{high_base_quality} cutoff. Passing a \code{which} argument
-  allows computing on only a subregion of the genome.
+  \code{high_base_quality} cutoff.
+
+  Passing a \code{which} argument allows computing on only a
+  subregion of the genome. \code{which} is a ‘RangesList’ or
+  something coercible to one that limits the tally to that range or
+  set of ranges. By default, the entire genome is processed.
+
+  For parallel evaluation (see \code{BPPARAM}): Specifically,
+  \code{which} can be a ‘GenomicRanges’ or a ‘GRangesList’. If
+  \code{which} is a ‘GenomicRanges’ and has length 1 it is tiled
+  to create chunks for parallel evaluation. If it is longer
+  than 1, each range becomes a chunk for parallel evaluation.
+  If \code{which} is a ‘GRangesList’, each element (i.e. each
+  ‘GenomicRanges’) becomes a chunk. The latter can be useful to
+  ensure balanced worker load, e.g. in the case of regions covering
+  multiple sequences(see \code{\link{equisplit}}).
 }
 \note{
   The \code{VariantTallyParam} constructor is \strong{DEPRECATED}.


### PR DESCRIPTION
Following a previous pull request (https://github.com/lawremi/VariantTools/pull/1), Michael Lawrence suggested to add an equisplit function (named epGRanges in the previous PR) to GenomicRanges (instead of VariantTools).

Proposed changes include an equisplit generic in  S4Vectors, an equisplit function (for GenomicRanges objects) in GenomicRanges and minor changes in VariantTools to accommodate param@bamTallyParam@which as GRangesList (in addition to GenomicRanges).